### PR TITLE
Add factored MonarchLinear block storage

### DIFF
--- a/iterativennsimple/MonarchLinear.py
+++ b/iterativennsimple/MonarchLinear.py
@@ -1,3 +1,4 @@
+import itertools
 import math
 import logging
 from typing import Any, TYPE_CHECKING
@@ -60,6 +61,25 @@ class MonarchLinear(nn.Module):
     out_features: int
     num_blocks: int
 
+    @staticmethod
+    def _factorization(n: int) -> tuple[int, int] | None:
+        """Return (base, exponent) if n is a perfect power n = base^exp with base ≥ 2, exp ≥ 2.
+
+        Picks the smallest base (deepest factorization) for maximum memory savings.
+        E.g. 8→(2,3), 9→(3,2), 16→(2,4), 64→(2,6), 6→None.
+        """
+        if n < 4:
+            return None
+        for base in range(2, n):
+            if base * base > n:
+                break
+            exp = round(math.log(n) / math.log(base))
+            # Check neighbours to avoid floating-point drift.
+            for e in (exp, exp + 1, exp - 1):
+                if e >= 2 and base ** e == n:
+                    return (base, e)
+        return None
+
     def __init__(
         self,
         in_features: int,
@@ -104,16 +124,36 @@ class MonarchLinear(nn.Module):
         self.block_out_features: list[int] = list(block_out_features)
         self.force_loop_matmul: bool = force_loop_matmul
 
-        # Trainable block weight matrices (each shape: (block_out_i, block_in_i))
-        self.blocks = nn.ParameterList(
-            [
+        # When blocks are uniform and square, and num_blocks is a perfect power
+        # n^k, we store only n factor matrices and compose all n^k ordered
+        # products (AA, AB, BA, BB, ...) via non-commutative matmul.
+        factoring = None
+        if (len(set(block_in_features)) == 1
+                and len(set(block_out_features)) == 1
+                and block_in_features[0] == block_out_features[0]):
+            factoring = MonarchLinear._factorization(self.num_blocks)
+
+        if factoring is not None:
+            self.num_factors, self.product_order = factoring
+            d = block_in_features[0]
+            # Shared factor matrices — the actual trainable parameters.
+            self.factors = nn.ParameterList([
+                nn.Parameter(torch.empty(d, d, **factory_kwargs), requires_grad=True)
+                for _ in range(self.num_factors)
+            ])
+            self.blocks = nn.ParameterList()  # empty; blocks are computed on the fly
+        else:
+            self.num_factors = None
+            self.product_order = None
+            self.factors = nn.ParameterList()  # empty; standard independent blocks
+            # Trainable block weight matrices (each shape: (block_out_i, block_in_i))
+            self.blocks = nn.ParameterList([
                 nn.Parameter(
                     torch.empty(block_out_features[i], block_in_features[i], **factory_kwargs),
                     requires_grad=True,
                 )
                 for i in range(self.num_blocks)
-            ]
-        )
+            ])
 
         # Permutation index arrays — registered as buffers so they travel with
         # the module (.to(device), state_dict) but receive no gradients.
@@ -130,6 +170,27 @@ class MonarchLinear(nn.Module):
         self.reset_parameters()
 
     # ------------------------------------------------------------------
+    # Factored block computation
+    # ------------------------------------------------------------------
+
+    def _effective_blocks(self) -> list[torch.Tensor]:
+        """Return block matrices — computed from factors when factored, else stored directly.
+
+        In factored mode, generates all n^k ordered products of the n factor
+        matrices.  Each product is a differentiable chain of matmuls so
+        gradients flow back to the shared factors.
+        """
+        if self.num_factors is None:
+            return list(self.blocks)
+        products = []
+        for indices in itertools.product(range(self.num_factors), repeat=self.product_order):
+            result = self.factors[indices[0]]
+            for idx in indices[1:]:
+                result = result @ self.factors[idx]
+            products.append(result)
+        return products
+
+    # ------------------------------------------------------------------
     # Initialisation
     # ------------------------------------------------------------------
 
@@ -137,6 +198,8 @@ class MonarchLinear(nn.Module):
         """Re-initialise block weights (Kaiming uniform) and bias."""
         for block in self.blocks:
             nn.init.kaiming_uniform_(block, a=math.sqrt(5))
+        for factor in self.factors:
+            nn.init.kaiming_uniform_(factor, a=math.sqrt(5))
         if self.bias is not None:
             fan_in = self.in_features
             bound = 1.0 / math.sqrt(fan_in) if fan_in > 0 else 0.0
@@ -169,6 +232,7 @@ class MonarchLinear(nn.Module):
             # only the columns each block needs, matmul, then scatter the result
             # directly into the output tensor.  Intermediate tensors are
             # block-sized and short-lived, avoiding two full-size copies.
+            blocks = self._effective_blocks()
             result = torch.empty(batch, self.out_features,
                                  device=input.device, dtype=input.dtype)
             in_off = 0
@@ -180,7 +244,7 @@ class MonarchLinear(nn.Module):
                 # input[:, idx] is a gather — copies only (batch, bi) elements.
                 x_block = input[:, self.perm_in[in_off:in_off + bi]]
                 # Write the block result directly into the correct output columns.
-                result[:, self.perm_out[out_off:out_off + bo]] = x_block @ self.blocks[i].T
+                result[:, self.perm_out[out_off:out_off + bo]] = x_block @ blocks[i].T
                 in_off += bi
                 out_off += bo
         else:
@@ -213,6 +277,7 @@ class MonarchLinear(nn.Module):
             Tensor of shape (batch, out_features).
         """
         batch = x.shape[0]
+        blocks = self._effective_blocks()
 
         # Fast path: all blocks have the same shape → single torch.bmm call.
         if not self.force_loop_matmul and len(set(self.block_in_features)) == 1 and len(set(self.block_out_features)) == 1:
@@ -222,7 +287,7 @@ class MonarchLinear(nn.Module):
             # → (batch, num_blocks, block_in) → (num_blocks, batch, block_in)
             x_3d = x.reshape(batch, self.num_blocks, block_in).permute(1, 0, 2)
             # blocks: list of (block_out, block_in)  →  (num_blocks, block_out, block_in)
-            W_3d = torch.stack(list(self.blocks))
+            W_3d = torch.stack(blocks)
             # bmm: (num_blocks, batch, block_in) × (num_blocks, block_in, block_out)
             #    = (num_blocks, batch, block_out)
             y_3d = torch.bmm(x_3d, W_3d.transpose(1, 2))
@@ -231,7 +296,7 @@ class MonarchLinear(nn.Module):
 
         # General path: non-uniform block sizes — loop over blocks.
         parts = torch.split(x, self.block_in_features, dim=1)
-        out_parts = [part @ self.blocks[i].T for i, part in enumerate(parts)]
+        out_parts = [part @ blocks[i].T for i, part in enumerate(parts)]
         return torch.cat(out_parts, dim=1)
 
     # ------------------------------------------------------------------
@@ -259,8 +324,8 @@ class MonarchLinear(nn.Module):
         Returns:
             Tensor of shape (out_features, in_features).
         """
-        # Build block-diagonal M from the trainable blocks.
-        M = torch.block_diag(*list(self.blocks))  # (out_features, in_features)
+        # Build block-diagonal M from the effective blocks.
+        M = torch.block_diag(*self._effective_blocks())  # (out_features, in_features)
 
         # S[perm_out[a], perm_in[b]] = M[a, b]  for all a, b.
         # Equivalently:
@@ -314,7 +379,7 @@ class MonarchLinear(nn.Module):
         # This is a straightforward but inefficient implementation of to_dense() that directly
         # computes the permutation matrices P1 and P2 and does the full matmul. Useful for testing against to_dense().
         # NOTE: Do not use in production code due to inefficiency.
-        M = torch.block_diag(*list(self.blocks))
+        M = torch.block_diag(*self._effective_blocks())
         P1 = torch.zeros(self.out_features, self.out_features, device=self.perm_out.device, dtype=M.dtype)
         P1[self.perm_out, torch.arange(self.out_features)] = 1.0
         P2 = torch.zeros(self.in_features, self.in_features, device=self.perm_in.device, dtype=M.dtype)
@@ -322,22 +387,28 @@ class MonarchLinear(nn.Module):
         return P1 @ M @ P2
 
     def number_of_trainable_parameters(self) -> int:
-        """Return the number of trainable scalar parameters (blocks + bias).
+        """Return the number of trainable scalar parameters (blocks/factors + bias).
 
         This matches the interface expected by Sequential2D.number_of_trainable_parameters().
         """
+        # One of blocks/factors is always empty; sum both for simplicity.
         total = sum(b.numel() for b in self.blocks)
+        total += sum(f.numel() for f in self.factors)
         if self.bias is not None:
             total += self.out_features
         return total
 
     def extra_repr(self) -> str:
-        return (
-            f"in_features={self.in_features}, "
-            f"out_features={self.out_features}, "
-            f"num_blocks={self.num_blocks}, "
-            f"bias={self.bias is not None}"
-        )
+        parts = [
+            f"in_features={self.in_features}",
+            f"out_features={self.out_features}",
+            f"num_blocks={self.num_blocks}",
+            f"bias={self.bias is not None}",
+        ]
+        if self.num_factors is not None:
+            parts.append(f"num_factors={self.num_factors}")
+            parts.append(f"product_order={self.product_order}")
+        return ", ".join(parts)
 
     # ------------------------------------------------------------------
     # Factory functions
@@ -448,6 +519,8 @@ class MonarchLinear(nn.Module):
         if initialization_type != "kaiming":
             for block in layer.blocks:
                 MonarchLinear._initialize_block(block, initialization_type)
+            for factor in layer.factors:
+                MonarchLinear._initialize_block(factor, initialization_type)
 
         return layer
 
@@ -555,9 +628,14 @@ class MonarchLinear(nn.Module):
             return in_features % k == 0 and out_features % k == 0
 
         # Search outward from ideal_k_int for a valid divisor.
+        # Prefer factorable candidates (perfect powers) for memory savings.
         num_blocks = None
         for delta in range(max(in_features, out_features)):
-            for candidate in [ideal_k_int + delta, ideal_k_int - delta]:
+            candidates = sorted(
+                {ideal_k_int + delta, ideal_k_int - delta},
+                key=lambda c: (MonarchLinear._factorization(c) is None, c),
+            )
+            for candidate in candidates:
                 if candidate >= 1 and is_valid(candidate):
                     num_blocks = candidate
                     break
@@ -639,9 +717,14 @@ class MonarchLinear(nn.Module):
         def is_valid(k: int) -> bool:
             return in_features % k == 0 and out_features % k == 0
 
+        # Prefer factorable candidates (perfect powers) for memory savings.
         num_blocks = None
         for delta in range(max(in_features, out_features)):
-            for candidate in [ideal_k_int + delta, ideal_k_int - delta]:
+            candidates = sorted(
+                {ideal_k_int + delta, ideal_k_int - delta},
+                key=lambda c: (MonarchLinear._factorization(c) is None, c),
+            )
+            for candidate in candidates:
                 if candidate >= 1 and is_valid(candidate):
                     num_blocks = candidate
                     break

--- a/notebooks/advanced/sparse_scripts/5-factored-monarch-benchmark.py
+++ b/notebooks/advanced/sparse_scripts/5-factored-monarch-benchmark.py
@@ -1,8 +1,8 @@
-# Benchmark: Factored vs Standard MonarchLinear block-diagonal storage.
+# Benchmark for MonarchLinear: parameter counts, timing, and memory.
 #
-# Measures parameter counts, forward/backward timing, and memory usage.
-# Works both before and after the factored block-diagonal change —
-# when factored mode is unavailable, reports "N/A" for factored columns.
+# Run this BEFORE and AFTER changes to compare. It only uses the public API
+# (from_uniform_blocks, number_of_trainable_parameters, forward, backward)
+# so it works on any version of the code.
 #
 # Usage:
 #   python notebooks/advanced/sparse_scripts/5-factored-monarch-benchmark.py
@@ -12,24 +12,13 @@ import torch
 from iterativennsimple.MonarchLinear import MonarchLinear
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def has_factored_support() -> bool:
-    """Check whether MonarchLinear has factored block-diagonal support."""
-    return hasattr(MonarchLinear, '_factorization')
-
-
-def time_forward_backward(layer, x, warmup: int = 5, repeats: int = 20) -> dict:
-    """Time forward and backward passes, returning millisecond averages."""
-    # Warmup
+def time_forward_backward(layer, x, warmup=10, repeats=50):
+    """Time forward and backward passes, return millisecond averages."""
     for _ in range(warmup):
         y = layer(x)
         y.sum().backward()
         layer.zero_grad()
 
-    # Timed runs
     fwd_ms, bwd_ms = 0.0, 0.0
     for _ in range(repeats):
         t0 = time.perf_counter()
@@ -41,140 +30,65 @@ def time_forward_backward(layer, x, warmup: int = 5, repeats: int = 20) -> dict:
         fwd_ms += (t1 - t0) * 1000
         bwd_ms += (t2 - t1) * 1000
 
-    return {
-        "forward_ms": fwd_ms / repeats,
-        "backward_ms": bwd_ms / repeats,
-        "total_ms": (fwd_ms + bwd_ms) / repeats,
-    }
+    return fwd_ms / repeats, bwd_ms / repeats
 
 
-def param_bytes(layer) -> int:
-    """Total bytes of stored parameter tensors."""
+def param_bytes(layer):
+    """Total bytes stored in parameter tensors."""
     return sum(p.numel() * p.element_size() for p in layer.parameters())
 
 
-# ---------------------------------------------------------------------------
-# 1. Parameter count comparison
-# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}")
+    factored = hasattr(MonarchLinear, '_factorization')
+    print(f"Factored support: {factored}\n")
 
-def benchmark_param_counts():
-    print("=" * 80)
-    print("1. PARAMETER COUNT COMPARISON")
-    print("=" * 80)
-    header = f"{'features':>8} {'num_blocks':>10} {'standard':>10} {'factored':>10} {'ratio':>8} {'factored?':>10}"
-    print(header)
-    print("-" * len(header))
-
-    # Include non-factorable num_blocks (2, 3, 5, 6, 7) alongside factorable ones
-    # (4, 8, 9, 16, 27) to show the contrast.
-    for features in [256, 512, 1024]:
-        for num_blocks in [2, 3, 4, 5, 6, 7, 8, 9, 16, 27, 32]:
-            if features % num_blocks != 0:
-                continue
-
-            # Standard: always create independent blocks (even if factoring available)
-            standard_params = num_blocks * (features // num_blocks) ** 2
-
-            if has_factored_support():
-                layer = MonarchLinear.from_uniform_blocks(features, features, num_blocks, seed=0)
-                factored_params = layer.number_of_trainable_parameters()
-                is_factored = layer.num_factors is not None
-                ratio = f"{factored_params / standard_params:.3f}"
-                f_str = f"{factored_params:>10}"
-                mode = "yes" if is_factored else "no"
-            else:
-                f_str = "N/A".rjust(10)
-                ratio = "N/A".rjust(8)
-                mode = "N/A".rjust(10)
-
-            print(f"{features:>8} {num_blocks:>10} {standard_params:>10} {f_str} {ratio:>8} {mode:>10}")
-    print()
-
-
-# ---------------------------------------------------------------------------
-# 2. Forward / backward timing
-# ---------------------------------------------------------------------------
-
-def benchmark_timing():
-    print("=" * 80)
-    print("2. FORWARD / BACKWARD TIMING (milliseconds)")
-    print("=" * 80)
-
-    if not has_factored_support():
-        print("  Factored mode not available — skipping timing comparison.\n")
-        return
-
-    batch = 64
-    configs = [
-        (512, 2),    # NOT factorable — baseline
-        (512, 4),    # factored: 2^2
-        (512, 8),    # factored: 2^3
-        (512, 16),   # factored: 2^4
-        (1024, 2),   # NOT factorable — baseline
-        (1024, 4),   # factored: 2^2
-        (1024, 8),   # factored: 2^3
-        (1024, 16),  # factored: 2^4
-        (1024, 32),  # factored: 2^5
-    ]
-
-    header = f"{'features':>8} {'blocks':>6} {'factored?':>9}  {'fwd_ms':>8} {'bwd_ms':>8} {'total_ms':>8}  {'params':>8}"
-    print(header)
-    print("-" * len(header))
-
-    for features, num_blocks in configs:
-        if features % num_blocks != 0:
-            continue
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        layer = MonarchLinear.from_uniform_blocks(features, features, num_blocks, bias=True, seed=42, device=device)
-        x = torch.randn(batch, features, device=device, requires_grad=True)
-        t = time_forward_backward(layer, x, warmup=10, repeats=50)
-        is_f = "yes" if layer.num_factors is not None else "no"
-        p = layer.number_of_trainable_parameters()
-        print(f"{features:>8} {num_blocks:>6} {is_f:>9}  {t['forward_ms']:>8.3f} {t['backward_ms']:>8.3f} {t['total_ms']:>8.3f}  {p:>8}")
-    print()
-
-
-# ---------------------------------------------------------------------------
-# 3. Memory comparison
-# ---------------------------------------------------------------------------
-
-def benchmark_memory():
-    print("=" * 80)
-    print("3. MEMORY USAGE (parameter tensor bytes)")
-    print("=" * 80)
-
-    if not has_factored_support():
-        print("  Factored mode not available — skipping memory comparison.\n")
-        return
-
-    header = f"{'features':>8} {'blocks':>6} {'standard_KB':>12} {'factored_KB':>12} {'savings':>8}"
-    print(header)
-    print("-" * len(header))
+    # -----------------------------------------------------------------------
+    # 1. Parameter counts and memory
+    # -----------------------------------------------------------------------
+    print("=" * 90)
+    print("STORED PARAMETERS & MEMORY")
+    print("=" * 90)
+    hdr = f"{'feat':>6} {'blocks':>6} {'blk_sz':>6} {'params':>10} {'KB':>10} {'factored':>8}"
+    print(hdr)
+    print("-" * len(hdr))
 
     for features in [512, 1024]:
         for num_blocks in [2, 3, 4, 5, 8, 9, 16, 27, 32]:
             if features % num_blocks != 0:
                 continue
-
-            # Standard param count (what it would be without factoring)
+            layer = MonarchLinear.from_uniform_blocks(
+                features, features, num_blocks, bias=True, seed=42,
+            )
+            params = layer.number_of_trainable_parameters()
+            kb = param_bytes(layer) / 1024
+            is_f = str(getattr(layer, 'num_factors', None) is not None)
             d = features // num_blocks
-            standard_bytes = num_blocks * d * d * 4  # float32 = 4 bytes
-
-            layer = MonarchLinear.from_uniform_blocks(features, features, num_blocks, seed=0)
-            actual_bytes = param_bytes(layer)
-
-            std_kb = standard_bytes / 1024
-            act_kb = actual_bytes / 1024
-            savings = f"{1 - actual_bytes / standard_bytes:.1%}" if actual_bytes < standard_bytes else "none"
-            print(f"{features:>8} {num_blocks:>6} {std_kb:>12.1f} {act_kb:>12.1f} {savings:>8}")
+            print(f"{features:>6} {num_blocks:>6} {d:>6} {params:>10} {kb:>10.1f} {is_f:>8}")
     print()
 
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    # 2. Forward / backward timing
+    # -----------------------------------------------------------------------
+    print("=" * 90)
+    print("FORWARD / BACKWARD TIMING (ms)")
+    print("=" * 90)
+    hdr = f"{'feat':>6} {'blocks':>6} {'params':>10}  {'fwd':>8} {'bwd':>8} {'total':>8}"
+    print(hdr)
+    print("-" * len(hdr))
 
-if __name__ == "__main__":
-    print(f"Factored block-diagonal support: {has_factored_support()}\n")
-    benchmark_param_counts()
-    benchmark_timing()
-    benchmark_memory()
+    batch = 64
+    configs = [
+        (512, 2), (512, 4), (512, 8), (512, 16),
+        (1024, 2), (1024, 4), (1024, 8), (1024, 16), (1024, 32),
+    ]
+    for features, num_blocks in configs:
+        layer = MonarchLinear.from_uniform_blocks(
+            features, features, num_blocks, bias=True, seed=42, device=device,
+        )
+        x = torch.randn(batch, features, device=device)
+        fwd, bwd = time_forward_backward(layer, x)
+        params = layer.number_of_trainable_parameters()
+        print(f"{features:>6} {num_blocks:>6} {params:>10}  {fwd:>8.3f} {bwd:>8.3f} {fwd+bwd:>8.3f}")
+    print()

--- a/notebooks/advanced/sparse_scripts/5-factored-monarch-benchmark.py
+++ b/notebooks/advanced/sparse_scripts/5-factored-monarch-benchmark.py
@@ -1,0 +1,180 @@
+# Benchmark: Factored vs Standard MonarchLinear block-diagonal storage.
+#
+# Measures parameter counts, forward/backward timing, and memory usage.
+# Works both before and after the factored block-diagonal change —
+# when factored mode is unavailable, reports "N/A" for factored columns.
+#
+# Usage:
+#   python notebooks/advanced/sparse_scripts/5-factored-monarch-benchmark.py
+
+import time
+import torch
+from iterativennsimple.MonarchLinear import MonarchLinear
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def has_factored_support() -> bool:
+    """Check whether MonarchLinear has factored block-diagonal support."""
+    return hasattr(MonarchLinear, '_factorization')
+
+
+def time_forward_backward(layer, x, warmup: int = 5, repeats: int = 20) -> dict:
+    """Time forward and backward passes, returning millisecond averages."""
+    # Warmup
+    for _ in range(warmup):
+        y = layer(x)
+        y.sum().backward()
+        layer.zero_grad()
+
+    # Timed runs
+    fwd_ms, bwd_ms = 0.0, 0.0
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        y = layer(x)
+        t1 = time.perf_counter()
+        y.sum().backward()
+        t2 = time.perf_counter()
+        layer.zero_grad()
+        fwd_ms += (t1 - t0) * 1000
+        bwd_ms += (t2 - t1) * 1000
+
+    return {
+        "forward_ms": fwd_ms / repeats,
+        "backward_ms": bwd_ms / repeats,
+        "total_ms": (fwd_ms + bwd_ms) / repeats,
+    }
+
+
+def param_bytes(layer) -> int:
+    """Total bytes of stored parameter tensors."""
+    return sum(p.numel() * p.element_size() for p in layer.parameters())
+
+
+# ---------------------------------------------------------------------------
+# 1. Parameter count comparison
+# ---------------------------------------------------------------------------
+
+def benchmark_param_counts():
+    print("=" * 80)
+    print("1. PARAMETER COUNT COMPARISON")
+    print("=" * 80)
+    header = f"{'features':>8} {'num_blocks':>10} {'standard':>10} {'factored':>10} {'ratio':>8} {'factored?':>10}"
+    print(header)
+    print("-" * len(header))
+
+    # Include non-factorable num_blocks (2, 3, 5, 6, 7) alongside factorable ones
+    # (4, 8, 9, 16, 27) to show the contrast.
+    for features in [256, 512, 1024]:
+        for num_blocks in [2, 3, 4, 5, 6, 7, 8, 9, 16, 27, 32]:
+            if features % num_blocks != 0:
+                continue
+
+            # Standard: always create independent blocks (even if factoring available)
+            standard_params = num_blocks * (features // num_blocks) ** 2
+
+            if has_factored_support():
+                layer = MonarchLinear.from_uniform_blocks(features, features, num_blocks, seed=0)
+                factored_params = layer.number_of_trainable_parameters()
+                is_factored = layer.num_factors is not None
+                ratio = f"{factored_params / standard_params:.3f}"
+                f_str = f"{factored_params:>10}"
+                mode = "yes" if is_factored else "no"
+            else:
+                f_str = "N/A".rjust(10)
+                ratio = "N/A".rjust(8)
+                mode = "N/A".rjust(10)
+
+            print(f"{features:>8} {num_blocks:>10} {standard_params:>10} {f_str} {ratio:>8} {mode:>10}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# 2. Forward / backward timing
+# ---------------------------------------------------------------------------
+
+def benchmark_timing():
+    print("=" * 80)
+    print("2. FORWARD / BACKWARD TIMING (milliseconds)")
+    print("=" * 80)
+
+    if not has_factored_support():
+        print("  Factored mode not available — skipping timing comparison.\n")
+        return
+
+    batch = 64
+    configs = [
+        (512, 2),    # NOT factorable — baseline
+        (512, 4),    # factored: 2^2
+        (512, 8),    # factored: 2^3
+        (512, 16),   # factored: 2^4
+        (1024, 2),   # NOT factorable — baseline
+        (1024, 4),   # factored: 2^2
+        (1024, 8),   # factored: 2^3
+        (1024, 16),  # factored: 2^4
+        (1024, 32),  # factored: 2^5
+    ]
+
+    header = f"{'features':>8} {'blocks':>6} {'factored?':>9}  {'fwd_ms':>8} {'bwd_ms':>8} {'total_ms':>8}  {'params':>8}"
+    print(header)
+    print("-" * len(header))
+
+    for features, num_blocks in configs:
+        if features % num_blocks != 0:
+            continue
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        layer = MonarchLinear.from_uniform_blocks(features, features, num_blocks, bias=True, seed=42, device=device)
+        x = torch.randn(batch, features, device=device, requires_grad=True)
+        t = time_forward_backward(layer, x, warmup=10, repeats=50)
+        is_f = "yes" if layer.num_factors is not None else "no"
+        p = layer.number_of_trainable_parameters()
+        print(f"{features:>8} {num_blocks:>6} {is_f:>9}  {t['forward_ms']:>8.3f} {t['backward_ms']:>8.3f} {t['total_ms']:>8.3f}  {p:>8}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# 3. Memory comparison
+# ---------------------------------------------------------------------------
+
+def benchmark_memory():
+    print("=" * 80)
+    print("3. MEMORY USAGE (parameter tensor bytes)")
+    print("=" * 80)
+
+    if not has_factored_support():
+        print("  Factored mode not available — skipping memory comparison.\n")
+        return
+
+    header = f"{'features':>8} {'blocks':>6} {'standard_KB':>12} {'factored_KB':>12} {'savings':>8}"
+    print(header)
+    print("-" * len(header))
+
+    for features in [512, 1024]:
+        for num_blocks in [2, 3, 4, 5, 8, 9, 16, 27, 32]:
+            if features % num_blocks != 0:
+                continue
+
+            # Standard param count (what it would be without factoring)
+            d = features // num_blocks
+            standard_bytes = num_blocks * d * d * 4  # float32 = 4 bytes
+
+            layer = MonarchLinear.from_uniform_blocks(features, features, num_blocks, seed=0)
+            actual_bytes = param_bytes(layer)
+
+            std_kb = standard_bytes / 1024
+            act_kb = actual_bytes / 1024
+            savings = f"{1 - actual_bytes / standard_bytes:.1%}" if actual_bytes < standard_bytes else "none"
+            print(f"{features:>8} {num_blocks:>6} {std_kb:>12.1f} {act_kb:>12.1f} {savings:>8}")
+    print()
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print(f"Factored block-diagonal support: {has_factored_support()}\n")
+    benchmark_param_counts()
+    benchmark_timing()
+    benchmark_memory()

--- a/tests/test_MonarchLinear.py
+++ b/tests/test_MonarchLinear.py
@@ -204,9 +204,11 @@ def test_gradient_flow():
 
 def test_gradient_matches_dense():
     torch.manual_seed(0)
-    layer = make_simple_monarch(in_f=16, out_f=16, seed=3)
-    x = torch.randn(8, 16)
-    target = torch.randn(8, 16)
+    # Use num_blocks=3 (not a perfect power) to avoid factored mode,
+    # since this test reconstructs S_grad from individual block gradients.
+    layer = MonarchLinear.from_uniform_blocks(18, 18, num_blocks=3, bias=True, seed=3)
+    x = torch.randn(8, 18)
+    target = torch.randn(8, 18)
 
     # --- MonarchLinear backward ---
     y_monarch = layer(x)
@@ -242,8 +244,9 @@ def test_gradient_matches_dense():
         col_offset += bir
 
     # --- Equivalent dense nn.Linear backward with the same effective S ---
+    n = layer.in_features
     S = layer.to_dense().detach()
-    dense = nn.Linear(16, 16, bias=True)
+    dense = nn.Linear(n, n, bias=True)
     with torch.no_grad():
         dense.weight.copy_(S)
         dense.bias.copy_(layer.bias.detach())
@@ -341,13 +344,20 @@ def test_to_device():
 # ---------------------------------------------------------------------------
 
 def test_number_of_trainable_parameters():
-    # 4 blocks, each 4×4 = 16 params, plus bias of length 16 → total 80
+    # 4 blocks of 4×4 with square features → factored (2 factors, order 2).
+    # Stored params: 2 factors × 4×4 = 32, plus bias 16 → 48.
     layer = make_simple_monarch(in_f=16, out_f=16, num_blocks=4, bias=True)
-    assert layer.number_of_trainable_parameters() == 4 * 4 * 4 + 16
+    assert layer.num_factors == 2  # factored: 4 = 2^2
+    assert layer.number_of_trainable_parameters() == 2 * 4 * 4 + 16
 
     # Without bias
     layer_nb = make_simple_monarch(in_f=16, out_f=16, num_blocks=4, bias=False)
-    assert layer_nb.number_of_trainable_parameters() == 4 * 4 * 4
+    assert layer_nb.number_of_trainable_parameters() == 2 * 4 * 4
+
+    # Non-factorable: 3 blocks (not a perfect power) — independent blocks.
+    layer_nf = MonarchLinear.from_uniform_blocks(18, 18, num_blocks=3, bias=True, seed=0)
+    assert layer_nf.num_factors is None
+    assert layer_nf.number_of_trainable_parameters() == 3 * 6 * 6 + 18
 
 
 # ---------------------------------------------------------------------------
@@ -418,12 +428,14 @@ def test_entry_target():
     in_f, out_f = 256, 256
     total = in_f * out_f  # 65536
 
-    # Ask for 1/4 of all entries → k=4 → 16384 entries
+    # Ask for 1/4 of all entries → k=4 → 16384 effective non-zero entries.
+    # (number_of_trainable_parameters reports stored params, which may be
+    #  fewer when factored; count non-zeros in the dense matrix instead.)
     target = total // 4
     layer = MonarchLinear.from_entry_target(in_f, out_f, target_entries=target, seed=3)
-    achieved = layer.number_of_trainable_parameters()
-    assert abs(achieved - target) <= 0.05 * target, \
-        f"achieved {achieved} entries, expected ~{target}"
+    effective_entries = layer.to_dense().count_nonzero().item()
+    assert abs(effective_entries - target) <= 0.05 * target, \
+        f"achieved {effective_entries} effective entries, expected ~{target}"
 
     # Exact match: target_entries == total → k=1 → dense layer
     layer_dense = MonarchLinear.from_entry_target(in_f, out_f, target_entries=total, seed=3)
@@ -522,3 +534,74 @@ def test_rectangular():
     y_dense = x @ S.T + layer.bias
     assert torch.allclose(y, y_dense, atol=1e-5), \
         f"rectangular: max diff {(y - y_dense).abs().max().item()}"
+
+
+# ---------------------------------------------------------------------------
+# Factored block-diagonal tests
+# ---------------------------------------------------------------------------
+
+def test_factored_memory_scaling():
+    """Factored mode stores n factor matrices, not n^k independent blocks."""
+    for num_blocks, exp_nf, exp_order in [(4, 2, 2), (8, 2, 3), (9, 3, 2), (16, 2, 4), (27, 3, 3)]:
+        d = 4
+        features = num_blocks * d
+        layer = MonarchLinear.from_uniform_blocks(features, features, num_blocks, seed=0)
+        assert layer.num_factors == exp_nf, \
+            f"num_blocks={num_blocks}: expected num_factors={exp_nf}, got {layer.num_factors}"
+        assert layer.product_order == exp_order, \
+            f"num_blocks={num_blocks}: expected product_order={exp_order}, got {layer.product_order}"
+        stored = layer.number_of_trainable_parameters()
+        expected = exp_nf * d * d  # only factor params, no bias
+        assert stored == expected, \
+            f"num_blocks={num_blocks}: expected {expected} stored params, got {stored}"
+
+
+def test_factored_forward_matches_dense():
+    """Forward output matches dense reconstruction for factored layers."""
+    for num_blocks in [4, 8, 9]:
+        d = 4
+        features = num_blocks * d
+        layer = MonarchLinear.from_uniform_blocks(features, features, num_blocks, bias=True, seed=7)
+        assert layer.num_factors is not None  # confirm factored mode
+
+        x = torch.randn(8, features)
+        y = layer(x)
+        S = layer.to_dense()
+        y_dense = x @ S.T + layer.bias
+        assert torch.allclose(y, y_dense, atol=1e-5), \
+            f"num_blocks={num_blocks}: max diff {(y - y_dense).abs().max().item()}"
+
+
+def test_factored_gradient_flow():
+    """Gradients reach factors (not blocks, which is empty in factored mode)."""
+    layer = MonarchLinear.from_uniform_blocks(16, 16, num_blocks=4, bias=True, seed=0)
+    assert layer.num_factors is not None
+    assert len(layer.blocks) == 0, "blocks should be empty in factored mode"
+
+    x = torch.randn(8, 16)
+    loss = layer(x).sum()
+    loss.backward()
+
+    for i, factor in enumerate(layer.factors):
+        assert factor.grad is not None, f"factor[{i}].grad is None"
+        assert factor.grad.shape == factor.shape
+    assert layer.bias.grad is not None
+    assert layer.perm_in.grad is None
+    assert layer.perm_out.grad is None
+
+
+def test_factored_not_applied_when_rectangular():
+    """Factored mode is not used for rectangular (non-square) blocks."""
+    layer = MonarchLinear.from_uniform_blocks(32, 16, num_blocks=4, seed=0)
+    assert layer.num_factors is None, "should not factor rectangular blocks"
+    assert len(layer.blocks) == 4
+
+
+def test_factored_not_applied_when_not_perfect_power():
+    """Factored mode is not used when num_blocks is not a perfect power."""
+    for num_blocks in [3, 5, 6, 7, 10]:
+        features = num_blocks * 4
+        layer = MonarchLinear.from_uniform_blocks(features, features, num_blocks, seed=0)
+        assert layer.num_factors is None, \
+            f"num_blocks={num_blocks}: should not factor (not a perfect power)"
+        assert len(layer.blocks) == num_blocks

--- a/tests/test_Sequential2D.py
+++ b/tests/test_Sequential2D.py
@@ -380,9 +380,10 @@ def test_sequential2D_monarch_parameter_count():
     """Verify trainable parameter count for a 1×1 MonarchLinear grid."""
     num_blocks = 4
     in_out = 64
-    # Each block: (in_out/num_blocks) * (in_out/num_blocks) weights + in_out biases
     block_size = in_out // num_blocks
-    expected = num_blocks * block_size * block_size + in_out  # weights + bias
+    # 4 = 2^2 → factored mode: 2 factor matrices of (block_size × block_size) + bias
+    num_factors = 2
+    expected = num_factors * block_size * block_size + in_out  # factors + bias
 
     cfg = {
         "in_features_list": [in_out],


### PR DESCRIPTION
- Factor square uniform block grids when num_blocks is a perfect power
- Update dense conversion, parameter counting, and initialization for shared factors
- Add benchmarks and tests for factored and non-factored paths

Before:
```
Device: cuda
Factored support: False

==========================================================================================
STORED PARAMETERS & MEMORY
==========================================================================================
  feat blocks blk_sz     params         KB factored
---------------------------------------------------
   512      2    256     131584      514.0    False
   512      4    128      66048      258.0    False
   512      8     64      33280      130.0    False
   512     16     32      16896       66.0    False
   512     32     16       8704       34.0    False
  1024      2    512     525312     2052.0    False
  1024      4    256     263168     1028.0    False
  1024      8    128     132096      516.0    False
  1024     16     64      66560      260.0    False
  1024     32     32      33792      132.0    False

==========================================================================================
FORWARD / BACKWARD TIMING (ms)
==========================================================================================
  feat blocks     params       fwd      bwd    total
----------------------------------------------------
   512      2     131584     0.242    0.293    0.535
   512      4      66048     0.437    0.542    0.980
   512      8      33280     0.977    1.170    2.147
   512     16      16896     2.077    2.334    4.411
  1024      2     525312     0.245    0.295    0.540
  1024      4     263168     0.442    0.520    0.962
  1024      8     132096     1.050    1.215    2.264
  1024     16      66560     1.671    2.007    3.678
  1024     32      33792     3.254    3.735    6.989
```

After:
```
Device: cuda
Factored support: True

==========================================================================================
STORED PARAMETERS & MEMORY
==========================================================================================
  feat blocks blk_sz     params         KB factored
---------------------------------------------------
   512      2    256     131584      514.0    False
   512      4    128      33280      130.0     True
   512      8     64       8704       34.0     True
   512     16     32       2560       10.0     True
   512     32     16       1024        4.0     True
  1024      2    512     525312     2052.0    False
  1024      4    256     132096      516.0     True
  1024      8    128      33792      132.0     True
  1024     16     64       9216       36.0     True
  1024     32     32       3072       12.0     True

==========================================================================================
FORWARD / BACKWARD TIMING (ms)
==========================================================================================
  feat blocks     params       fwd      bwd    total
----------------------------------------------------
   512      2     131584     0.243    0.294    0.538
   512      4      33280     0.485    0.665    1.150
   512      8       8704     1.619    2.084    3.703
   512     16       2560     2.876    4.270    7.146
  1024      2     525312     0.242    0.294    0.536
  1024      4     132096     0.508    0.670    1.178
  1024      8      33792     1.031    1.469    2.499
  1024     16       9216     2.381    3.630    6.011
  1024     32       3072     4.814    7.944   12.758
  ```