### PR TITLE
Simplify monarch MNIST example

### DIFF
--- a/examples/monarch_mnist.py
+++ b/examples/monarch_mnist.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python
+"""
+Monarch INN vs LSTM on Fashion-MNIST with rotations.
+
+Treats image pixels as a sequence of chunks and classifies using an
+iterative Monarch sparse map, with an LSTM baseline for comparison.
+
+Dataset: Fashion-MNIST with 0-45° rotations and 0.75-1× scaling
+(10 classes, random baseline = 10%).
+
+Usage
+-----
+    uv run examples/monarch_mnist.py                              # both models
+    uv run examples/monarch_mnist.py --model monarch              # Monarch only
+    uv run examples/monarch_mnist.py --dataset MNIST --epochs 5   # quick MNIST
+    uv run examples/monarch_mnist.py --list-datasets              # show all datasets
+"""
+
 import time
 
 import click
@@ -12,212 +29,118 @@ from iterativennsimple.MonarchLinear import MonarchLinear
 from iterativennsimple.Sequential1D import Sequential1D
 from iterativennsimple.Sequential2D import Sequential2D, Identity
 
-# ---------------------------------------------------------------------------
-# Presets
-# ---------------------------------------------------------------------------
-PRESETS = {
-    "quick": {
-        "h_sizes":     [64],
-        "num_blocks":  4,
-        "iterations":  3,
-        "lstm_hidden": 64,
-        "lstm_layers": 1,
-        "lr":          1e-3,
-        "epochs":      10,
-        "batch_size":  256,
-    },
-    "small": {
-        "h_sizes":     [128, 128],
-        "num_blocks":  4,
-        "iterations":  4,
-        "lstm_hidden": 128,
-        "lstm_layers": 2,
-        "lr":          1e-3,
-        "epochs":      20,
-        "batch_size":  256,
-    },
-    "medium": {
-        "h_sizes":     [8192],
-        "num_blocks":  8,
-        "iterations":  5,
-        "lstm_hidden": 0,
-        "lstm_layers": 0,
-        "lr":          5e-4,
-        "epochs":      40,
-        "batch_size":  32,
-    },
-    "large": {
-        "h_sizes":     [512, 512, 512],
-        "num_blocks":  8,
-        "iterations":  6,
-        "lstm_hidden": 0,
-        "lstm_layers": 0,
-        "lr":          2e-4,
-        "epochs":      60,
-        "batch_size":  256,
-    },
-}
+# -- Default dataset (Fashion-MNIST with moderate rotation + scaling) --------
+DEFAULT_DATASET = (
+    "FashionMNIST_custom_degrees0_45_translate0_0.0_scale0.75_1_randomerasing_0.0"
+)
+
+# -- Hyperparameters ---------------------------------------------------------
+HIDDEN_SIZES = [128, 128]   # two hidden slots in the Monarch state vector
+NUM_BLOCKS   = 4            # Monarch blocks per layer (controls sparsity)
+ITERATIONS   = 4            # map applications per time-step
+STEP_SIZE    = 4            # pixels per time-step (must divide image size)
+LSTM_HIDDEN  = 128          # LSTM hidden size (comparable param budget)
+LSTM_LAYERS  = 2            # LSTM layers
+LR           = 1e-3
+EPOCHS       = 20
+BATCH_SIZE   = 256
 
 
 # ---------------------------------------------------------------------------
-# Data loading  (delegates to generatedata)
+# Data
 # ---------------------------------------------------------------------------
 
-def load_split(
-    name: str,
-    step_size: int,
-    local: bool,
-    label_every_step: bool,
-    val_fraction: float = 1 / 7,
-    seed: int = 42,
-):
-    """
-    Load a generatedata dataset as a pixel-chunk sequence and split train/val.
-
-    Returns
-    -------
-    X_train, y_train, X_val, y_val : tensors
-    label_dim                       : number of output classes
-    input_dim                       : features per time-step
-                                      (= step_size + label_dim if label_every_step)
-    """
+def load_dataset(name, step_size, local=False, val_frac=1 / 7, seed=42):
+    """Load a generatedata dataset, split into train/val torch tensors."""
     X_seq, labels = load_data_as_sequence(
-        name,
-        step_size=step_size,
-        local=local,
-        label_every_step=label_every_step,
+        name, step_size=step_size, local=local, label_every_step=True,
     )
-    # X_seq  : (N, seq_len, step_size [+ label_dim])  numpy float
-    # labels : (N, label_dim)                          numpy float one-hot
-    X_seq  = torch.from_numpy(X_seq.astype(np.float32))
-    labels = torch.from_numpy(labels.astype(np.float32))
+    X = torch.from_numpy(X_seq.astype(np.float32))
+    y = torch.from_numpy(labels.astype(np.float32)).argmax(dim=1)
 
-    label_dim = labels.shape[1]
-    input_dim = X_seq.shape[2]       # step_size or step_size + label_dim
-    y_cls     = labels.argmax(dim=1) # (N,) integer class indices
-
-    N   = len(X_seq)
-    rng = np.random.default_rng(seed)
-    idx = rng.permutation(N)
-    n_val = max(1, int(N * val_fraction))
-    val_idx, train_idx = idx[:n_val], idx[n_val:]
+    # Reproducible train/val split
+    N   = len(X)
+    idx = np.random.default_rng(seed).permutation(N)
+    n_val = max(1, int(N * val_frac))
 
     return (
-        X_seq[train_idx], y_cls[train_idx],
-        X_seq[val_idx],   y_cls[val_idx],
-        label_dim, input_dim,
+        X[idx[n_val:]], y[idx[n_val:]],   # train
+        X[idx[:n_val]], y[idx[:n_val]],    # val
+        labels.shape[1],                   # label_dim  (number of classes)
+        X.shape[2],                        # input_dim  (features per step)
     )
-
-
-def supervised_step_set(seq_len: int, supervise_every: int) -> set:
-    """
-    Return the set of time-step indices at which to compute a loss.
-
-    supervise_every == 0  ->  last step only
-    supervise_every == N  ->  every Nth step (last step always included)
-    """
-    if supervise_every == 0:
-        return {seq_len - 1}
-    steps = set(range(supervise_every - 1, seq_len, supervise_every))
-    steps.add(seq_len - 1)
-    return steps
 
 
 # ---------------------------------------------------------------------------
 # Models
 # ---------------------------------------------------------------------------
 
-def _make_monarch_block(in_f, out_f, num_blocks, activation=None):
+# ---- Monarch INN ----------------------------------------------------------
+
+def _monarch_block(in_f, out_f, num_blocks, activation=None):
+    """Single MonarchLinear block, optionally preceded by an activation."""
     nb = num_blocks
     while nb > 1 and (in_f % nb != 0 or out_f % nb != 0):
         nb -= 1
     layer = MonarchLinear.from_uniform_blocks(
-        in_features=in_f, out_features=out_f, num_blocks=nb, bias=True)
-    act_map = {"ReLU": nn.ReLU, "ELU": nn.ELU, "Tanh": nn.Tanh}
-    seq = nn.Sequential(act_map[activation](), layer) if activation in act_map \
-          else nn.Sequential(layer)
-    return Sequential1D(seq, in_features=in_f, out_features=out_f)
+        in_features=in_f, out_features=out_f, num_blocks=nb, bias=True,
+    )
+    modules = [activation, layer] if activation else [layer]
+    return Sequential1D(nn.Sequential(*modules), in_features=in_f, out_features=out_f)
 
 
-def _build_seq2d(input_dim, h_sizes, label_dim, num_blocks, activation="ReLU"):
+def _build_map(input_dim, hidden_sizes, label_dim, num_blocks):
     """
-    Build the Sequential2D map.
+    Build the Sequential2D iterative map.
 
-    State: [x(input_dim) | h1 | ... | hk | y(label_dim)]
+    State vector: [ x (input) | h1 | ... | hk | y (output) ]
 
-    blocks[0][0]   = Identity  -- x frozen during inner iterations
-    blocks[i][i+1] = MonarchLinear  -- feed-forward chain
+    The map is a feed-forward chain  x -> h1 -> ... -> hk -> y
+    with x held fixed (Identity) so inputs persist across iterations.
     """
-    sizes  = [input_dim] + list(h_sizes) + [label_dim]
+    sizes  = [input_dim] + list(hidden_sizes) + [label_dim]
     n      = len(sizes)
     blocks = [[None] * n for _ in range(n)]
     blocks[0][0] = Identity(in_features=input_dim, out_features=input_dim)
     for i in range(n - 1):
-        act = None if i == 0 else activation
-        blocks[i][i + 1] = _make_monarch_block(sizes[i], sizes[i + 1], num_blocks, act)
+        act = nn.ReLU() if i > 0 else None
+        blocks[i][i + 1] = _monarch_block(sizes[i], sizes[i + 1], num_blocks, act)
     return Sequential2D(sizes, sizes, blocks)
 
 
-class MonarchSequenceClassifier(nn.Module):
+class MonarchClassifier(nn.Module):
     """
-    Monarch INN used as a recurrent sequence classifier.
+    Monarch INN sequence classifier.
 
-    The sequence is processed one chunk at a time.  At each step:
-      - Overwrite the x-slot of the state with the current input chunk.
-      - Apply the Monarch map `iterations` times.
-    A CrossEntropy loss is computed at each step in `sup_steps` and summed.
+    At each time-step: write the chunk into the x-slot, then apply the
+    Monarch map ``iterations`` times.  Returns logits from the y-slot.
     """
 
-    def __init__(self, input_dim, h_sizes, label_dim, num_blocks, activation="ReLU"):
+    def __init__(self, input_dim, hidden_sizes, label_dim, num_blocks):
         super().__init__()
         self.input_dim = input_dim
-        self.h_sizes   = list(h_sizes)
         self.label_dim = label_dim
-        self.seq2d     = _build_seq2d(input_dim, h_sizes, label_dim, num_blocks, activation)
+        self.hidden_sizes = list(hidden_sizes)
+        self.map = _build_map(input_dim, hidden_sizes, label_dim, num_blocks)
 
-    def forward(self, x_seq, iterations, sup_steps, criterion, targets):
-        """
-        Parameters
-        ----------
-        x_seq      : (B, T, input_dim)
-        iterations : Monarch map applications per time-step
-        sup_steps  : set of time-step indices at which to compute loss
-        criterion  : loss function  (logits, class_indices)
-        targets    : (B,) integer class labels
-
-        Returns
-        -------
-        loss   : scalar -- sum of losses at all supervised steps
-        logits : (B, label_dim) -- y-slot at the final time-step
-        """
+    def forward(self, x_seq):
         B, T, _ = x_seq.shape
-        total_h = sum(self.h_sizes)
-        state   = torch.zeros(
-            B, self.input_dim + total_h + self.label_dim, device=x_seq.device)
-        state[:, -self.label_dim:] = 1.0 / self.label_dim  # uniform y-init
-
-        loss = torch.tensor(0.0, device=x_seq.device)
+        state_dim = self.input_dim + sum(self.hidden_sizes) + self.label_dim
+        state = torch.zeros(B, state_dim, device=x_seq.device)
+        state[:, -self.label_dim:] = 1.0 / self.label_dim  # uniform prior
 
         for t in range(T):
             state[:, :self.input_dim] = x_seq[:, t, :]
-            for _ in range(iterations):
-                state = self.seq2d(state)
-            if t in sup_steps:
-                loss = loss + criterion(state[:, -self.label_dim:], targets)
+            for _ in range(ITERATIONS):
+                state = self.map(state)
 
-        return loss, state[:, -self.label_dim:]
+        return state[:, -self.label_dim:]
 
-    def number_of_trainable_parameters(self):
-        return self.seq2d.number_of_trainable_parameters()
 
+# ---- LSTM baseline --------------------------------------------------------
 
 class LSTMClassifier(nn.Module):
-    """
-    Standard LSTM sequence classifier (baseline).
-
-    Processes the sequence step by step so that intermediate-step losses can
-    be computed at the same sup_steps as the Monarch model.
-    """
+    """Standard LSTM sequence classifier (baseline)."""
 
     def __init__(self, input_dim, hidden_size, num_layers, label_dim):
         super().__init__()
@@ -228,98 +151,62 @@ class LSTMClassifier(nn.Module):
         )
         self.fc = nn.Linear(hidden_size, label_dim)
 
-    def forward(self, x_seq, sup_steps, criterion, targets):
-        """
-        Parameters
-        ----------
-        x_seq     : (B, T, input_dim)
-        sup_steps : set of time-step indices at which to compute loss
-        criterion : loss function
-        targets   : (B,) integer class labels
-
-        Returns
-        -------
-        loss   : scalar -- sum of losses at supervised steps
-        logits : (B, label_dim) -- output at the final supervised step
-        """
-        B, T, _ = x_seq.shape
-        h_state = None
-        loss    = torch.tensor(0.0, device=x_seq.device)
-        logits  = torch.zeros(B, self.fc.out_features, device=x_seq.device)
-
-        for t in range(T):
-            out, h_state = self.lstm(x_seq[:, t:t + 1, :], h_state)
-            if t in sup_steps:
-                logits = self.fc(out[:, 0, :])
-                loss   = loss + criterion(logits, targets)
-
-        # If the last step wasn't supervised, still produce final logits
-        if (T - 1) not in sup_steps:
-            logits = self.fc(out[:, 0, :])  # out is still valid from last iteration
-
-        return loss, logits
+    def forward(self, x_seq):
+        out, _ = self.lstm(x_seq)
+        return self.fc(out[:, -1, :])  # classify from last hidden state
 
 
 # ---------------------------------------------------------------------------
-# Training loop
+# Training
 # ---------------------------------------------------------------------------
 
-def _run_epoch(model, loader, optimizer, criterion, device, train,
-               sup_steps, is_monarch, monarch_iters=0):
+def run_epoch(model, loader, optimizer, criterion, device, train=True):
+    """Run one epoch.  Returns (avg_loss, accuracy%)."""
     model.train(train)
-    total_loss, correct, total = 0.0, 0, 0
+    total_loss, correct, count = 0.0, 0, 0
 
     with torch.set_grad_enabled(train):
-        for x_seq, targets in loader:
-            x_seq, targets = x_seq.to(device), targets.to(device)
-
-            if is_monarch:
-                loss, logits = model(x_seq, monarch_iters, sup_steps, criterion, targets)
-            else:
-                loss, logits = model(x_seq, sup_steps, criterion, targets)
+        for X, y in loader:
+            X, y = X.to(device), y.to(device)
+            logits = model(X)
+            loss = criterion(logits, y)
 
             if train:
                 optimizer.zero_grad()
                 loss.backward()
                 optimizer.step()
 
-            total_loss += loss.item() * len(x_seq)
-            correct    += (logits.detach().argmax(1) == targets).sum().item()
-            total      += len(x_seq)
+            total_loss += loss.item() * len(X)
+            correct += (logits.detach().argmax(1) == y).sum().item()
+            count += len(X)
 
-    return total_loss / total, correct / total * 100
+    return total_loss / count, correct / count * 100
 
 
-def train_and_eval(model, train_loader, val_loader, cfg, device,
-                   sup_steps, is_monarch, label="model"):
-    """Train for cfg['epochs'] epochs.  Returns (best_val_acc, best_epoch, elapsed_s)."""
+def train_model(model, train_loader, val_loader, device, epochs, label="model"):
+    """Train for ``epochs`` epochs.  Returns (best_val_acc, elapsed_seconds)."""
     criterion = nn.CrossEntropyLoss()
-    optimizer = torch.optim.Adam(model.parameters(), lr=cfg["lr"])
+    optimizer = torch.optim.Adam(model.parameters(), lr=LR)
 
-    best_val_acc, best_epoch = 0.0, 0
+    best_val_acc = 0.0
     t0 = time.time()
 
-    for epoch in range(1, cfg["epochs"] + 1):
+    for epoch in range(1, epochs + 1):
         t_epoch = time.time()
-        tr_loss, tr_acc = _run_epoch(
-            model, train_loader, optimizer, criterion, device,
-            train=True, sup_steps=sup_steps,
-            is_monarch=is_monarch, monarch_iters=cfg.get("iterations", 0))
-        _, val_acc = _run_epoch(
-            model, val_loader, None, criterion, device,
-            train=False, sup_steps=sup_steps,
-            is_monarch=is_monarch, monarch_iters=cfg.get("iterations", 0))
+        tr_loss, tr_acc = run_epoch(
+            model, train_loader, optimizer, criterion, device, train=True,
+        )
+        _, val_acc = run_epoch(
+            model, val_loader, None, criterion, device, train=False,
+        )
+        best_val_acc = max(best_val_acc, val_acc)
         epoch_s = time.time() - t_epoch
 
-        if val_acc > best_val_acc:
-            best_val_acc = val_acc
-            best_epoch   = epoch
-
-        print(f"  [{label}] epoch {epoch:3d}/{cfg['epochs']}  "
-              f"loss={tr_loss:.4f}  train={tr_acc:.1f}%  val={val_acc:.2f}%  "
+        print(f"  [{label}] epoch {epoch:3d}/{epochs}  "
+              f"loss {tr_loss:.4f}  train {tr_acc:.1f}%  val {val_acc:.1f}%  "
               f"({epoch_s:.1f}s)")
 
-    return best_val_acc, best_epoch, int(time.time() - t0)
+    return best_val_acc, time.time() - t0
 
 
 # ---------------------------------------------------------------------------
@@ -327,186 +214,92 @@ def train_and_eval(model, train_loader, val_loader, cfg, device,
 # ---------------------------------------------------------------------------
 
 @click.command()
-@click.option("--list-datasets", is_flag=True, default=False,
-              help="Print available dataset names and exit.")
-@click.option("--local", is_flag=True, default=False,
-              help="Load from local processed directory instead of remote.")
-# Dataset
-@click.option("--dataset", default=None,
-              help="generatedata dataset name (see --list-datasets).")
-@click.option("--step-size", type=int, default=1, show_default=True,
-              help="Feature values per time-step (must divide x_y_index).")
-@click.option("--label-every-step/--no-label-every-step", default=True, show_default=True,
-              help="Append one-hot ground-truth label to every input chunk.")
-@click.option("--supervise-every", type=int, default=0, show_default=True,
-              help="Backprop on loss every N steps "
-                   "(0 = last step only; 1 = every step; N = every Nth step).")
-# Model
-@click.option("--model",
-              type=click.Choice(["monarch", "lstm", "both"], case_sensitive=False),
-              default="both", show_default=True,
-              help="Which model(s) to train and compare.")
-@click.option("--preset",
-              type=click.Choice(list(PRESETS)), default="small", show_default=True,
-              help="Architecture / training preset.")
-# Monarch overrides
-@click.option("--h-sizes",    type=int, multiple=True,
-              help="Monarch hidden-layer widths (overrides preset).")
-@click.option("--num-blocks", type=int, default=None,
-              help="Monarch blocks per layer (overrides preset).")
-@click.option("--iterations", type=int, default=None,
-              help="Monarch map applications per time-step (overrides preset).")
-# LSTM overrides
-@click.option("--lstm-hidden", type=int, default=None,
-              help="LSTM hidden size (overrides preset).")
-@click.option("--lstm-layers", type=int, default=None,
-              help="LSTM number of layers (overrides preset).")
-# Training
-@click.option("--lr",           type=float, default=None, help="Learning rate.")
-@click.option("--epochs",       type=int,   default=None, help="Training epochs.")
-@click.option("--batch-size",   type=int,   default=None, help="Mini-batch size.")
-@click.option("--val-fraction", type=float, default=1 / 7, show_default=True,
-              help="Fraction of data held out for validation.")
-@click.option("--seed",         type=int,   default=42, show_default=True)
-def main(
-    list_datasets, local,
-    dataset, step_size, label_every_step, supervise_every,
-    model, preset,
-    h_sizes, num_blocks, iterations,
-    lstm_hidden, lstm_layers,
-    lr, epochs, batch_size, val_fraction, seed,
-):
-    # ── List mode ─────────────────────────────────────────────────────────────
+@click.option("--list-datasets", is_flag=True, help="Print available datasets and exit.")
+@click.option("--local", is_flag=True, help="Load from local cache instead of remote.")
+@click.option("--dataset", default=DEFAULT_DATASET, show_default=False,
+              help="Dataset name (default: Fashion-MNIST with rotations).")
+@click.option("--model", type=click.Choice(["monarch", "lstm", "both"], case_sensitive=False),
+              default="both", show_default=True, help="Which model(s) to train.")
+@click.option("--epochs", default=EPOCHS, show_default=True, help="Training epochs.")
+@click.option("--seed", default=42, show_default=True, help="Random seed.")
+def main(list_datasets, local, dataset, model, epochs, seed):
     if list_datasets:
-        names = data_names(local=local)
-        print(f"Available datasets ({'local' if local else 'remote'}):")
-        for n in sorted(names):
-            print(f"  {n}")
+        for name in sorted(data_names(local=local)):
+            print(name)
         return
-
-    if dataset is None:
-        raise click.UsageError(
-            "Please specify --dataset NAME.  "
-            "Use --list-datasets to see available options.")
 
     torch.manual_seed(seed)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    # ── Config ────────────────────────────────────────────────────────────────
-    cfg = dict(PRESETS[preset])
-    if h_sizes:     cfg["h_sizes"]     = list(h_sizes)
-    if num_blocks:  cfg["num_blocks"]  = num_blocks
-    if iterations:  cfg["iterations"]  = iterations
-    if lstm_hidden: cfg["lstm_hidden"] = lstm_hidden
-    if lstm_layers: cfg["lstm_layers"] = lstm_layers
-    if lr:          cfg["lr"]          = lr
-    if epochs:      cfg["epochs"]      = epochs
-    if batch_size:  cfg["batch_size"]  = batch_size
+    # -- Data ----------------------------------------------------------------
+    info = load_data(dataset, local=local)["info"]
+    seq_len = info["x_y_index"] // STEP_SIZE
 
-    # ── Load data ─────────────────────────────────────────────────────────────
-    info      = load_data(dataset, local=local)["info"]
-    x_y_index = info["x_y_index"]
-    seq_len   = x_y_index // step_size
-
-    print(f"Dataset : {dataset}")
-    print(f"  x_y_index={x_y_index}  step_size={step_size}  seq_len={seq_len}")
-    print(f"  label_every_step={label_every_step}")
-
-    X_train, y_train, X_val, y_val, label_dim, input_dim = load_split(
-        dataset, step_size=step_size, local=local,
-        label_every_step=label_every_step,
-        val_fraction=val_fraction, seed=seed,
+    X_tr, y_tr, X_va, y_va, label_dim, input_dim = load_dataset(
+        dataset, step_size=STEP_SIZE, local=local,
+    )
+    train_loader = torch.utils.data.DataLoader(
+        torch.utils.data.TensorDataset(X_tr, y_tr),
+        batch_size=BATCH_SIZE, shuffle=True,
+    )
+    val_loader = torch.utils.data.DataLoader(
+        torch.utils.data.TensorDataset(X_va, y_va),
+        batch_size=BATCH_SIZE,
     )
 
-    sup_steps = supervised_step_set(seq_len, supervise_every)
-    sup_preview = sorted(sup_steps)[:8]
-    sup_suffix  = "..." if len(sup_steps) > 8 else ""
-
-    print(f"  train={len(y_train):,}  val={len(y_val):,}")
-    print(f"  label_dim={label_dim}  input_dim={input_dim}")
-    print(f"  supervise_every={supervise_every}  "
-          f"-> {len(sup_steps)} supervised step(s)  "
-          f"(steps: {sup_preview}{sup_suffix})")
-    print(f"  device={device}  preset={preset}")
-
-    train_loader = torch.utils.data.DataLoader(
-        torch.utils.data.TensorDataset(X_train, y_train),
-        batch_size=cfg["batch_size"], shuffle=True)
-    val_loader = torch.utils.data.DataLoader(
-        torch.utils.data.TensorDataset(X_val, y_val),
-        batch_size=cfg["batch_size"])
+    print(f"Dataset      : {dataset}")
+    print(f"  samples    : {len(y_tr):,} train / {len(y_va):,} val")
+    print(f"  seq_len    : {seq_len}  (step_size={STEP_SIZE})")
+    print(f"  classes    : {label_dim}  (random baseline = {100/label_dim:.0f}%)")
+    print(f"  device     : {device}")
 
     results = {}
 
-    # ── Monarch ───────────────────────────────────────────────────────────────
+    # -- Monarch -------------------------------------------------------------
     if model in ("monarch", "both"):
-        monarch = MonarchSequenceClassifier(
+        monarch = MonarchClassifier(
             input_dim=input_dim,
-            h_sizes=cfg["h_sizes"],
+            hidden_sizes=HIDDEN_SIZES,
             label_dim=label_dim,
-            num_blocks=cfg["num_blocks"],
+            num_blocks=NUM_BLOCKS,
         ).to(device)
 
-        n_params    = monarch.number_of_trainable_parameters()
-        sizes       = [input_dim] + cfg["h_sizes"] + [label_dim]
+        n_params    = monarch.map.number_of_trainable_parameters()
+        sizes       = [input_dim] + HIDDEN_SIZES + [label_dim]
         dense_equiv = sum(sizes[i] * sizes[i + 1] for i in range(len(sizes) - 1))
         sparsity    = 1.0 - n_params / dense_equiv
 
-        print(f"\n{'='*60}")
-        print(f"Monarch INN  h_sizes={cfg['h_sizes']}  "
-              f"num_blocks={cfg['num_blocks']}  iterations={cfg['iterations']}")
-        print(f"  params={n_params:,}  dense_equiv={dense_equiv:,}  sparsity={sparsity:.2f}")
+        print(f"\nMonarch INN  state=[{' + '.join(str(s) for s in sizes)}]  "
+              f"blocks={NUM_BLOCKS}  iters={ITERATIONS}")
+        print(f"  params={n_params:,}  (dense equiv {dense_equiv:,}, sparsity {sparsity:.0%})")
 
-        best_acc, best_ep, elapsed = train_and_eval(
-            monarch, train_loader, val_loader, cfg, device,
-            sup_steps=sup_steps, is_monarch=True, label="Monarch")
+        acc, elapsed = train_model(monarch, train_loader, val_loader, device, epochs, "Monarch")
+        results["Monarch"] = {"acc": acc, "params": n_params, "sparsity": sparsity, "time": elapsed}
 
-        results["Monarch"] = dict(
-            acc=best_acc, epoch=best_ep, elapsed=elapsed,
-            params=n_params, sparsity=sparsity)
-
-    # ── LSTM ──────────────────────────────────────────────────────────────────
+    # -- LSTM ----------------------------------------------------------------
     if model in ("lstm", "both"):
         lstm = LSTMClassifier(
             input_dim=input_dim,
-            hidden_size=cfg["lstm_hidden"],
-            num_layers=cfg["lstm_layers"],
+            hidden_size=LSTM_HIDDEN,
+            num_layers=LSTM_LAYERS,
             label_dim=label_dim,
         ).to(device)
 
         n_params_lstm = sum(p.numel() for p in lstm.parameters() if p.requires_grad)
 
-        print(f"\n{'='*60}")
-        print(f"LSTM baseline  hidden={cfg['lstm_hidden']}  layers={cfg['lstm_layers']}")
+        print(f"\nLSTM baseline  hidden={LSTM_HIDDEN}  layers={LSTM_LAYERS}")
         print(f"  params={n_params_lstm:,}")
 
-        best_acc, best_ep, elapsed = train_and_eval(
-            lstm, train_loader, val_loader, cfg, device,
-            sup_steps=sup_steps, is_monarch=False, label="LSTM")
+        acc, elapsed = train_model(lstm, train_loader, val_loader, device, epochs, "LSTM")
+        results["LSTM"] = {"acc": acc, "params": n_params_lstm, "sparsity": None, "time": elapsed}
 
-        results["LSTM"] = dict(
-            acc=best_acc, epoch=best_ep, elapsed=elapsed,
-            params=n_params_lstm, sparsity=None)
-
-    # ── Summary ───────────────────────────────────────────────────────────────
-    print(f"\n{'='*60}")
-    print("SUMMARY")
-    print(f"  dataset         : {dataset}")
-    print(f"  step_size       : {step_size}   seq_len={seq_len}")
-    print(f"  label_every_step: {label_every_step}   input_dim={input_dim}")
-    print(f"  supervised steps: {len(sup_steps)} / {seq_len}  "
-          f"(supervise_every={supervise_every})")
-    print(f"  random baseline : {100 / label_dim:.1f}%")
-    print()
-    hdr = (f"{'Model':<14} {'Val Acc':>8} {'BestEp':>7} "
-           f"{'Params':>10} {'Sparsity':>9} {'Time':>7}")
-    print(hdr)
-    print("-" * len(hdr))
+    # -- Summary -------------------------------------------------------------
+    print(f"\n{'='*55}")
+    print(f"{'Model':<12} {'Val Acc':>8} {'Params':>10} {'Sparsity':>9} {'Time':>8}")
+    print(f"{'-'*55}")
     for name, r in results.items():
-        mins, secs = divmod(r["elapsed"], 60)
-        sp = f"{r['sparsity']:.2f}" if r["sparsity"] is not None else "  n/a"
-        print(f"{name:<14} {r['acc']:>7.2f}%  {r['epoch']:>6}  "
-              f"{r['params']:>10,}  {sp:>8}  {mins}m{secs:02d}s")
+        sp = f"{r['sparsity']:.0%}" if r['sparsity'] is not None else "  n/a"
+        print(f"{name:<12} {r['acc']:>7.1f}%  {r['params']:>10,}  {sp:>8}  {r['time']:>6.0f}s")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Replace preset-heavy CLI with a fixed default dataset and simpler flags
- Streamline Monarch and LSTM classifiers to a shared epoch loop
- Update output to report concise accuracy, sparsity, and runtime summary

_The previous code was more of a personal playground. This is cleaner and clearer for others to use as a starting point._

